### PR TITLE
Touchpad was listed twice in DeviceButton docs.

### DIFF
--- a/api/lovr/headset/DeviceButton.lua
+++ b/api/lovr/headset/DeviceButton.lua
@@ -26,10 +26,6 @@ return {
       description = 'The menu button.'
     },
     {
-      name = 'touchpad',
-      description = 'The button on the touchpad.'
-    },
-    {
       name = 'a',
       description = 'The A button.'
     },


### PR DESCRIPTION
`touchpad` was listed twice in the DeviceButton docs. This change just removes the 2nd instance.