### PR TITLE
Oculus Mobile fixes

### DIFF
--- a/examples/Instancing/main.lua
+++ b/examples/Instancing/main.lua
@@ -3,6 +3,10 @@
 function lovr.load()
   MONKEYS = 1000
 
+  if lovr.headset.getDriver() ~= "oculusmobile" then -- That's too many monkeys!!!
+    MONKEYS = 700
+  end
+
   -- Create a ShaderBlock to store positions for lots of models
   block = lovr.graphics.newShaderBlock('uniform', {
     modelTransforms = { 'mat4', MONKEYS }

--- a/examples/Instancing/main.lua
+++ b/examples/Instancing/main.lua
@@ -1,11 +1,7 @@
 -- Surround yourself with monkeys, efficiently
 
 function lovr.load()
-  MONKEYS = 1000
-
-  if lovr.headset.getDriver() ~= "oculusmobile" then -- That's too many monkeys!!!
-    MONKEYS = 700
-  end
+  MONKEYS = 700
 
   -- Create a ShaderBlock to store positions for lots of models
   block = lovr.graphics.newShaderBlock('uniform', {

--- a/guides/Getting_Started_(Android).md
+++ b/guides/Getting_Started_(Android).md
@@ -21,17 +21,17 @@ but there are lots of other guides on the internet for how to do this.  The key 
 Install the APK
 ---
 
-Download the latest release version of the appsample apk from the [`lovr-oculus-mobile` release
+Download the latest release version of the test apk from the [`lovr-oculus-mobile` release
 page](https://github.com/mcclure/lovr-oculus-mobile/releases).
 
 Install it to the device:
 
 ```
-$ adb install /path/to/appsample-release.apk
+$ adb install /path/to/test-release.apk
 ```
 
 Try running it by navigating to the "Library" -> "Unknown Sources" menu of the headset and running
-the `org.lovr.test` app.  You should see LÖVR's "no game" screen with the logo.
+the `org.lovr.test` app.  You should see a message about how to upload files.
 
 Running a Project
 ---


### PR DESCRIPTION
* Corrections to the Android getting started page, re: name scheme of the org.lovr.test app
* Too many monkeys. Reduce the number of monkeys

Should be merged into 0.13.0 and master