### PR TITLE
PBR example: fix normal map flag in `flags`

### DIFF
--- a/examples/PBR_Materials/main.lua
+++ b/examples/PBR_Materials/main.lua
@@ -3,7 +3,7 @@ function lovr.load()
 
   shader = lovr.graphics.newShader('standard', {
     flags = {
-      normalTexture = false,
+      normalMap = false,
       indirectLighting = true,
       occlusion = true,
       emissive = true,


### PR DESCRIPTION
afaict this example is the only documentation for the flags for the PBR/standard shader. Reading the source, I can only find `FLAG_normalMap` and no `FLAG_normalTexture` (though the uniform is called `lovrNormalTexture`), so it'd be great to update the documentation to match :) (assuming that I understood the source correct and this is a valid fix)