### PR TITLE
Minor fix: Don't name sample parameter 'repeat'

### DIFF
--- a/api/lovr/callbacks/keypressed.lua
+++ b/api/lovr/callbacks/keypressed.lua
@@ -14,7 +14,7 @@ return {
       description = 'The id of the key (ignores keyboard layout, may vary between keyboards).'
     },
     {
-      name = 'repeat',
+      name = 'repeating',
       type = 'boolean',
       description = 'Whether the event is the result of a key repeat instead of an actual press.'
     }


### PR DESCRIPTION
Turns out "repeat" is a lua reserved word