### PR TITLE
corrected Normal calculation in Simple Lighting Tutorial

### DIFF
--- a/guides/Simple_Lighting.md
+++ b/guides/Simple_Lighting.md
@@ -100,7 +100,7 @@ Luckily, LÖVR loves you, and makes this very easy. Here's the new vertex shade
 
         vec4 position(mat4 projection, mat4 transform, vec4 vertex) 
         { 
-            Normal = lovrNormal * lovrNormalMatrix;
+            Normal = lovrNormalMatrix * lovrNormal;
             FragmentPos = vec3(lovrModel * vertex);
             
             return projection * transform * vertex; 


### PR DESCRIPTION
All I have done in this is corrected the calculation of the Normal in the vertex shader in the Simple Lighting Tutorial to the correct order:

```
        Normal = lovrNormalMatrix * lovrNormal;
```

This is meant to address the following issue on the lovr repo: https://github.com/bjornbytes/lovr/issues/501 . 

Thanks @shakesoda for identifying the issue for me.