### PR TITLE
Fix Window_HUD example for 0.16

### DIFF
--- a/examples/UI/Window_HUD/main.lua
+++ b/examples/UI/Window_HUD/main.lua
@@ -107,9 +107,8 @@ end
 
 -- Draw HUD overlay
 function lovr.mirror(pass)
-	if mirror then mirror() end
 	pass:origin()
-  pass:setViewPose(1, mat4())
+	pass:setViewPose(1, mat4())
 	pass:setProjection(1, matrix) -- Switch to screen space coordinates
 	drawGrid(pass)
 


### PR DESCRIPTION
This entailed updating lovr-mouse, then doing some unusual things to allow "draw mirror on top of headset view" behavior.

This code works in master but NOT in 0.17/dev. The mesh creation line has to be rewritten to 0.17 spec.

You will probably need to update the manifest again after merging either of these.