### PR TITLE
Document new `raw` option in `newShader`

### DIFF
--- a/api/init.lua
+++ b/api/init.lua
@@ -12484,7 +12484,7 @@ return {
           name = "newShader",
           tag = "graphics-objects",
           summary = "Create a new Shader.",
-          description = "Creates a Shader, which is a small program that runs on the GPU.\n\nShader code is usually written in GLSL and compiled to SPIR-V bytecode.  SPIR-V is faster to load but requires a build step.  Either form can be used to create a shader.",
+          description = "Creates a Shader, which is a small program that runs on the GPU.\n\nShader code is usually written in GLSL and compiled to SPIR-V bytecode.  SPIR-V is faster to load but requires a build step.  Either form can be used to create a shader.\n\nBy default, the provided shader code is expected to implement a `void lovrmain() { ... }` function that is called for each vertex or fragment.  If the `raw` option is set to `true`, the code is treated as a raw shader and the `lovrmain` function is not required. In this case, the shader code is expected to implement its own `main` function.",
           key = "lovr.graphics.newShader",
           module = "lovr.graphics",
           related = {
@@ -12520,6 +12520,11 @@ return {
                       name = "label",
                       type = "string",
                       description = "A label to use for the shader in debugging tools."
+                    },
+                    {
+                      name = "raw",
+                      type = "boolean",
+                      description = "If set to true, the code is treated as a raw shader."
                     }
                   }
                 }
@@ -12554,6 +12559,11 @@ return {
                       name = "label",
                       type = "string",
                       description = "A label to use for the shader in debugging tools."
+                    },
+                    {
+                      name = "raw",
+                      type = "boolean",
+                      description = "If set to true, the code is treated as a raw shader."
                     }
                   }
                 }
@@ -12588,6 +12598,11 @@ return {
                       name = "label",
                       type = "string",
                       description = "A label to use for the shader in debugging tools."
+                    },
+                    {
+                      name = "raw",
+                      type = "boolean",
+                      description = "If set to true, the code is treated as a raw shader."
                     }
                   }
                 }

--- a/api/lovr/graphics/newShader.lua
+++ b/api/lovr/graphics/newShader.lua
@@ -6,6 +6,11 @@ return {
 
     Shader code is usually written in GLSL and compiled to SPIR-V bytecode.  SPIR-V is faster to
     load but requires a build step.  Either form can be used to create a shader.
+
+    By default, the provided shader code is expected to implement a `void lovrmain() { ... }`
+    function that is called for each vertex or fragment.  If the `raw` option is set to `true`, the
+    code is treated as a raw shader and the `lovrmain` function is not required. In this case, the
+    shader code is expected to implement its own `main` function.
   ]],
   arguments = {
     vertex = {
@@ -49,7 +54,12 @@ return {
           name = 'label',
           type = 'string',
           description = 'A label to use for the shader in debugging tools.'
-        }
+        },
+        {
+          name = 'raw',
+          type = 'boolean',
+          description = 'If set to true, the code is treated as a raw shader.'
+        },
       }
     }
   },


### PR DESCRIPTION
Adds documentation for the new `raw` flag added to `l.g.newShader` in https://github.com/bjornbytes/lovr/commit/85a9dceda61acd51d6959430be6be63982539efb.