### PR TITLE
Fix buffer init in Pass:mesh example snippet

### DIFF
--- a/api/lovr/graphics/Pass/mesh.lua
+++ b/api/lovr/graphics/Pass/mesh.lua
@@ -182,9 +182,9 @@ return {
   example = [[
     function lovr.load()
       local vertices = {
-        vec3(  0,  .4, 0), vec4(1, 0, 0, 1),
-        vec3(-.5, -.4, 0), vec4(0, 1, 0, 1),
-        vec3( .5, -.4, 0), vec4(0, 0, 1, 1)
+        { vec3(  0,  .4, 0), vec4(1, 0, 0, 1) },
+        { vec3(-.5, -.4, 0), vec4(0, 1, 0, 1) },
+        { vec3( .5, -.4, 0), vec4(0, 0, 1, 1) }
       }
 
       local format = {
@@ -198,5 +198,8 @@ return {
     function lovr.draw(pass)
       pass:mesh(triangle, 0, 1.7, -1)
     end
-  ]]
+  ]],
+  related = {
+    'Pass:setMeshMode',
+  }
 }


### PR DESCRIPTION
Before the fix the snippet throws error:
```
main.lua:13: Bad type for struct buffer data: table expected, got userdata
```