### PR TITLE
Remove setResponseTime usages in physics examples

### DIFF
--- a/examples/Physics/Wrecking_Ball/main.lua
+++ b/examples/Physics/Wrecking_Ball/main.lua
@@ -1,6 +1,6 @@
---[[ Wrecking ball suspended from rope. Cyrus-free.
+--[[ Wrecking ball suspended from rope.
 
-Making realtime rope simulation is finicky on any physics engine. At certain weight the force becomes
+Making realtime rope simulation is finicky in any physics engine. At certain weight the force becomes
 too much to be successfully distributed among rope elements.
 
 Some steps that can help solve the issue:
@@ -23,8 +23,9 @@ function lovr.load()
   local hanger = world:newBoxCollider(hangerPosition, vec3(0.3, 0.1, 0.3))
   hanger:setKinematic(true)
   -- ball
-  local ballPosition = vec3(-1, 1, -1)
+  local ballPosition = vec3(-1, 1.5, -1)
   local ball = world:newSphereCollider(ballPosition, 0.2)
+  ball:setMass(10)
   -- rope
   local firstEnd, lastEnd = makeRope(
     hangerPosition + vec3(0, -0.1, 0),
@@ -80,16 +81,11 @@ function makeRope(origin, destination, thickness, elements)
     local position = vec3(origin):lerp(destination, (i - 0.5) / elements)
     local anchor   = vec3(origin):lerp(destination, (i - 1.0) / elements)
     element = world:newBoxCollider(position, vec3(thickness, thickness, elementSize * 0.95))
-    element:setRestitution(0.1)
     element:setGravityIgnored(true)
     element:setOrientation(quat(orientation))
-    element:setLinearDamping(0.01)
-    element:setAngularDamping(0.01)
-    element:setMass(0.001)
+    element:setMass(0.1)
     if prev then
-      local joint = lovr.physics.newBallJoint(prev, element, anchor)
-      joint:setResponseTime(10)
-      joint:setTightness(1)
+      local joint = lovr.physics.newHingeJoint(prev, element)
     else
       first = element
     end

--- a/examples/Physics/Zip_Line/main.lua
+++ b/examples/Physics/Zip_Line/main.lua
@@ -5,24 +5,28 @@ using slider joint. Beware that slider joint loses its accuracy/stability when a
 objects are too far away. Increasing object mass of helps with stability.            --]]
 
 local world
+local p1 = Vec3(1, 1.9, -1)
+local p2 = Vec3(-1, 2, -1)
+local p3 = Vec3(-1, 1.5, -1)
 
 function lovr.load()
   world = lovr.physics.newWorld(0, -3, 0, false)
-  local hanger = world:newBoxCollider(vec3(1, 1.9, -1), vec3(0.1, 0.1, 0.3))
+  local hanger = world:newBoxCollider(p1, 0.1, 0.1, 0.3)
   hanger:setKinematic(true)
-  local trolley = world:newBoxCollider(vec3(-1, 2, -1), vec3(0.2, 0.2, 0.5))
+  local trolley = world:newBoxCollider(p2, 0.2, 0.2, 0.5)
   trolley:setRestitution(0.7)
   -- calculate axis that passes through centers of hanger and trolley
-  local sliderAxis = vec3(hanger:getPosition()) - vec3(trolley:getPosition())
+  local sliderAxis = p1 - p2
   -- constraint the trolley so that it can only slide along specified axis without any rotation
   joint = lovr.physics.newSliderJoint(hanger, trolley, sliderAxis)
   -- hang a weight from trolley
-  local weight = world:newCapsuleCollider(vec3(-1, 1.5, -1), 0.1, 0.4)
+  local weight = world:newCapsuleCollider(p3, 0.1, 0.4)
   weight:setOrientation(math.pi/2, 1,0,0)
   weight:setLinearDamping(0.005)
   weight:setAngularDamping(0.01)
-  local joint = lovr.physics.newDistanceJoint(trolley, weight, vec3(trolley:getPosition()), vec3(weight:getPosition()) + vec3(0, 0.3, 0))
-  joint:setResponseTime(10) -- make the hanging rope streachable
+  local joint = lovr.physics.newDistanceJoint(trolley, weight,
+    p2, p3 + vec3(0, 0.3, 0))
+  joint:setSpring(4, 0.5) -- make the hanging rope streachable
 
   lovr.graphics.setBackgroundColor(0.1, 0.1, 0.1)
 end
@@ -34,6 +38,7 @@ end
 
 
 function lovr.draw(pass)
+  pass:line(p1, p2)
   for i, collider in ipairs(world:getColliders()) do
     pass:setColor(0.6, 0.6, 0.6)
     local shape = collider:getShapes()[1]


### PR DESCRIPTION
Fix two examples that used setResponseTime. Just a basic touch up for now; still not on `vector()` API.