### PR TITLE
Add ShaderFlags

### DIFF
--- a/api/init.lua
+++ b/api/init.lua
@@ -10203,6 +10203,82 @@ return {
           }
         },
         {
+          name = "ShaderFlags",
+          summary = "Built-in Shader flags.",
+          description = "Built-in shader flags. Shaders can use both user-created specialization constants (or simply "flags") alongside the following built-in ones.",
+          key = "ShaderFlags",
+          module = "lovr.graphics",
+          related = {
+            "lovr.graphics.newShader"
+          },
+          values = {
+            {
+              name = 'pointSize',
+              description = '(flag ID = 1000, default value = 1.f) Defines the point size in pixels when using "pass:points".'
+            },
+            {
+              name = 'passColor',
+              description = '(flag ID = 1002, default value = true) Use the pass color defined by "pass:setColor".'
+            },
+	        {
+              name = 'materialColor',
+              description = '(flag ID = 1003, default value = true) Use the base color of the material.'
+            },
+            {
+              name = 'vertexColors',
+              description = '(flag ID = 1004, default value = true) Use the color contribution from the vertex colors.'
+            },
+            {
+              name = 'uvTransform',
+              description = '(flag ID = 1005, default value = true) TODO.'
+            },
+            {
+              name = 'alphaCutoff',
+              description = '(flag ID = 1006, default value = false) TODO.'
+            },
+            {
+              name = 'glow',
+              description = '(flag ID = 1007, default value = false) TODO.'
+            },
+            {
+              name = 'normalMap',
+              description = '(flag ID = 1008, default value = false) Use the normal map of the material.'
+            },
+            {
+              name = 'vertexTangents',
+              description = '(flag ID = 1009, default value = true) Use the vertex tangents of the model.'
+            },
+            {
+              name = 'colorTexture',
+              description = '(flag ID = 1010, default value = true) Use the color texture of the material.'
+            },
+            {
+              name = 'glowTexture',
+              description = '(flag ID = 1011, default value = true) Use the glow texture of the material.'
+            },
+            {
+              name = 'metalnessTexture',
+              description = '(flag ID = 1012, default value = true) Use the metalness texture of the material.'
+            },
+            {
+              name = 'roughnessTexture',
+              description = '(flag ID = 1013, default value = true) Use the roughness texture of the material.'
+            },
+            {
+              name = 'ambientOcclusion',
+              description = '(flag ID = 1014, default value = true) TODO.'
+            },
+            {
+              name = 'clearcoatTexture',
+              description = '(flag ID = 1015, default value = false) Use the clearcoat texture of the material.'
+            },
+            {
+              name = 'tonemap',
+              description = '(flag ID = 1016, default value = false) Use tonemap.'
+            },
+          }
+        },
+        {
           name = "StackType",
           summary = "Types of stacks that can be pushed and popped.",
           description = "Different types of stacks that can be pushed and popped with `Pass:push` and `Pass:pop`.",
@@ -11803,7 +11879,7 @@ return {
                   table = {
                     {
                       name = "flags",
-                      type = "table",
+                      type = "{ShaderFlags}",
                       description = "A table of shader flags.  The keys of the table should be flag names or flag ID numbers. The values can be numbers or booleans, depending on the type of the flag as declared in the shader."
                     },
                     {
@@ -21166,7 +21242,7 @@ return {
                     },
                     {
                       name = "flags",
-                      type = "table",
+                      type = "{ShaderFlags}",
                       description = "The flags used by the clone."
                     }
                   },

--- a/api/lovr/graphics/Shader/clone.lua
+++ b/api/lovr/graphics/Shader/clone.lua
@@ -10,7 +10,7 @@ return {
       description = 'The Shader to clone.'
     },
     flags = {
-      type = 'table',
+      type = '{ShaderFlags}',
       description = 'The flags used by the clone.'
     }
   },

--- a/api/lovr/graphics/ShaderFlags.lua
+++ b/api/lovr/graphics/ShaderFlags.lua
@@ -1,0 +1,73 @@
+return {
+  summary = 'Built-in Shader flags.',
+  description = 'Built-in shader flags. Shaders can use both user-created specialization constants (or simply "flags") alongside the following built-in ones.',
+  values = {
+    {
+      name = 'pointSize',
+      description = '(flag ID = 1000, default value = 1.f) Defines the point size in pixels when using "pass:points".'
+    },
+    {
+      name = 'passColor',
+      description = '(flag ID = 1002, default value = true) Use the pass color defined by "pass:setColor".'
+    },
+	{
+      name = 'materialColor',
+      description = '(flag ID = 1003, default value = true) Use the base color of the material.'
+    },
+    {
+      name = 'vertexColors',
+      description = '(flag ID = 1004, default value = true) Use the color contribution from the vertex colors.'
+    },
+    {
+      name = 'uvTransform',
+      description = '(flag ID = 1005, default value = true) TODO.'
+    },
+    {
+      name = 'alphaCutoff',
+      description = '(flag ID = 1006, default value = false) TODO.'
+    },
+    {
+      name = 'glow',
+      description = '(flag ID = 1007, default value = false) TODO.'
+    },
+    {
+      name = 'normalMap',
+      description = '(flag ID = 1008, default value = false) Use the normal map of the material.'
+    },
+    {
+      name = 'vertexTangents',
+      description = '(flag ID = 1009, default value = true) Use the vertex tangents of the model.'
+    },
+    {
+      name = 'colorTexture',
+      description = '(flag ID = 1010, default value = true) Use the color texture of the material.'
+    },
+    {
+      name = 'glowTexture',
+      description = '(flag ID = 1011, default value = true) Use the glow texture of the material.'
+    },
+    {
+      name = 'metalnessTexture',
+      description = '(flag ID = 1012, default value = true) Use the metalness texture of the material.'
+    },
+    {
+      name = 'roughnessTexture',
+      description = '(flag ID = 1013, default value = true) Use the roughness texture of the material.'
+    },
+    {
+      name = 'ambientOcclusion',
+      description = '(flag ID = 1014, default value = true) TODO.'
+    },
+    {
+      name = 'clearcoatTexture',
+      description = '(flag ID = 1015, default value = false) Use the clearcoat texture of the material.'
+    },
+    {
+      name = 'tonemap',
+      description = '(flag ID = 1016, default value = false) Use tonemap.'
+    },
+  },
+  related = {
+    'lovr.graphics.newShader'
+  }
+}

--- a/guides/Shaders.md
+++ b/guides/Shaders.md
@@ -756,3 +756,85 @@ Flags are declared using the `constant_id` qualifier, and can be overridden in
 LÖVR reserves `constant_id` values of 1000 and above.  Flag names may be prefixed with `flag_` to
 separate them from other GLSL variables.  The `flag_` prefix will be stripped when matching against
 flag table keys in `lovr.graphics.newShader`.
+
+Built-in shader functions
+---
+Shaders can make use of the following built-in helper functions:  
+TODO Add the Surface struct and Surface related functions?
+
+### Texture helpers
+The `getPixel` function can be used to sample pixels from texture resources, using the default sampler set with Pass:setSampler.  
+
+    vec4 getPixel(texture2D t, vec2 uv)
+    vec4 getPixel(texture3D t, vec3 uvw)
+    vec4 getPixel(textureCube t, vec3 dir)
+    vec4 getPixel(texture2DArray t, vec2 uv, float layer)
+    vec4 getPixel(textureCubeArray t, vec4 coord)
+
+	//TODO Add the sampler overloads too?
+
+### Lighting helpers
+The `D_GGX` function is an implementation of the Trowbridge-Reitz GGX Normal Distribution Function (NDF). It can be used to calculate specular highlight intensity.
+
+    float D_GGX(const Surface surface, float NoH)
+The `G_SmithGGXCorrelated` function implements the Heitz's Smith Joint Masking-Shadowing Function. It can be used for TODO...
+
+    float G_SmithGGXCorrelated(const Surface surface, float NoV, float NoL)
+
+The `F_Schlick` function approximates the Fresnel factor.
+
+    vec3 F_Schlick(const Surface surface, float VoH)
+
+The `getLighting` function evaluates a direct light for a given surface.
+
+    vec3 getLighting(const Surface surface, vec3 direction, vec4 color, float visibility)
+
+The `prefilteredBRDF` function TODO...  
+Reference: https://www.unrealengine.com/en-US/blog/physically-based-shading-on-mobile
+
+    vec2 prefilteredBRDF(float NoV, float roughness)
+
+The `evaluateSphericalHarmonics` function can be used for a fast approximation of global illumination.
+
+    vec3 evaluateSphericalHarmonics(vec3 sh[9], vec3 n)
+
+The `getIndirectLighting` function calculates indirect lighting for a surface.
+
+    vec3 getIndirectLighting(const Surface surface, textureCube environment, vec3 sphericalHarmonics[9])
+### Color conversion helpers
+The `tonemap` function transforms HDR color values to [0, 1] range.
+
+    vec3 tonemap(vec3 x)
+
+The `gammaToLinear` function converts a color from sRGB to Linear space.
+
+    vec3 gammaToLinear(vec3 color)
+
+The `linearToGamma` function converts a color from Linear to sRGB space.
+
+    vec3 linearToGamma(vec3 color)
+
+The `pqToLinear` function can be used for TODO...
+
+    vec3 pqToLinear(vec3 color)
+
+The `linearToPQ` function can be used for TODO...
+
+    vec3 linearToPQ(vec3 color)
+
+The `sRGBToRec2020` function converts a color from sRGB to Rec.2020 space.
+
+    vec3 sRGBToRec2020(vec3 color)
+
+The `rec2020ToSRGB` function converts a color from Rec.2020 to sRGB space.
+
+    vec3 rec2020ToSRGB(vec3 color)
+
+### Misc helpers
+The `packSnorm10x3` function can be used for TODO...
+
+    uint packSnorm10x3(vec4 v)
+
+The `unpackSnorm10x3` function can be used for TODO...
+
+    vec4 unpackSnorm10x3(uint n)

--- a/guides/Shaders.md
+++ b/guides/Shaders.md
@@ -429,6 +429,111 @@ fragment shaders.  Textures can be sampled using the `getPixel` helper function.
   </tbody>
 </table>
 
+The following built-in variables are definitions for special GLSL built-in variables.
+
+<table>
+  <thead>
+    <tr>
+      <td>Name</td>
+      <td>Type</td>
+      <td>Notes</td>
+      <td>Stage</td>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>BaseInstance</code></td>
+      <td>int</td>
+      <td><code>gl_BaseInstance</code></td>
+      <td>Vertex</td>
+    </tr>
+    <tr>
+      <td><code>BaseVertex</code></td>
+      <td>int</td>
+      <td><code>gl_BaseVertex</code></td>
+	  <td>Vertex</td>
+    </tr>
+    <tr>
+      <td><code>DrawIndex</code></td>
+      <td>int</td>
+      <td><code>gl_DrawID</code></td>
+	  <td>Vertex</td>
+    </tr>
+    <tr>
+      <td><code>InstanceIndex</code></td>
+      <td>int</td>
+      <td><code>gl_InstanceIndex</code></td>
+	  <td>Vertex</td>
+    </tr>
+    <tr>
+      <td><code>PointSize</code></td>
+      <td>float</td>
+      <td><code>gl_PointSize</code></td>
+	  <td>Vertex</td>
+    </tr>
+    <tr>
+      <td><code>Position</code></td>
+      <td>vec4</td>
+      <td><code>gl_Position</code></td>
+	  <td>Vertex</td>
+    </tr>
+    <tr>
+      <td><code>VertexIndex</code></td>
+      <td>int</td>
+      <td><code>gl_VertexIndex</code></td>
+	  <td>Vertex</td>
+    </tr>
+    <tr>
+      <td><code>FragCoord</code></td>
+      <td>vec4</td>
+      <td><code>gl_FragCoord</code></td>
+	  <td>Fragment</td>
+    </tr>
+    <tr>
+      <td><code>FragDepth</code></td>
+      <td>float</td>
+      <td><code>gl_FragDepth</code></td>
+	  <td>Fragment</td>
+    </tr>
+    <tr>
+      <td><code>FrontFacing</code></td>
+      <td>bool</td>
+      <td><code>gl_FrontFacing</code></td>
+	  <td>Fragment</td>
+    </tr>
+    <tr>
+      <td><code>PointCoord</code></td>
+      <td>vec2</td>
+      <td><code>gl_PointCoord</code></td>
+	  <td>Fragment</td>
+    </tr>
+    <tr>
+      <td><code>SampleID</code></td>
+      <td>int</td>
+      <td><code>gl_SampleID</code></td>
+	  <td>Fragment</td>
+    </tr>
+    <tr>
+      <td><code>SampleMaskIn</code></td>
+      <td>int[ ]</td>
+      <td><code>gl_SampleMaskIn</code></td>
+	  <td>Fragment</td>
+    </tr>
+    <tr>
+      <td><code>SampleMask</code></td>
+      <td>int[ ]</td>
+      <td><code>gl_SampleMask</code></td>
+	  <td>Fragment</td>
+    </tr>
+    <tr>
+      <td><code>SamplePosition</code></td>
+      <td>vec2</td>
+      <td><code>gl_SamplePosition</code></td>
+	  <td>Fragment</td>
+    </tr>
+  </tbody>
+</table>
+
 Shader Inputs
 ---
 


### PR DESCRIPTION
Docs for ShaderFlags. This might be a bit confusing for users though, because they'd think they can only use the built-in ones when browsing the docs for `newShader` and `Shader:clone`