### PR TITLE
`Shader:clone` does not take source shader as argument

### DIFF
--- a/api/lovr/graphics/Shader/clone.lua
+++ b/api/lovr/graphics/Shader/clone.lua
@@ -5,10 +5,6 @@ return {
     to create several variants of a shader with different behavior.
   ]],
   arguments = {
-    source = {
-      type = 'Shader',
-      description = 'The Shader to clone.'
-    },
     flags = {
       type = 'table',
       description = [[
@@ -27,7 +23,7 @@ return {
   },
   variants = {
     {
-      arguments = { 'source', 'flags' },
+      arguments = { 'flags' },
       returns = { 'shader' }
     }
   }


### PR DESCRIPTION
The `:clone` method is an instance method, so the source shader is `self`, and is not given as an additional argument. The [implementation](https://github.com/bjornbytes/lovr/blob/ef5bc4c00bb6758cecdaf20a93644a3ecb30b69c/src/api/l_graphics_shader.c#L6) reflects this, taking `self` as argument 1 (as per normal for instance methods), and the flags table as arg 2.